### PR TITLE
docs: lead with self-hosting; retire dead public server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,44 @@ verification, this is not recommended and should only be used for testing
 purposes. Consider using a private CA or certificates signed using
 [Let's Encrypt](https://letsencrypt.org/) instead.
 
+## Self-hosting (recommended)
+
+Run your own server. It keeps your audio on your own hardware, it does not
+depend on somebody else's uptime, and you choose the model.
+
+```bash
+pip install ovos-stt-http-server ovos-stt-plugin-onnx-asr
+ovos-stt-server --engine ovos-stt-plugin-onnx-asr
+```
+
+[ovos-stt-plugin-onnx-asr](https://github.com/OpenVoiceOS/ovos-stt-plugin-onnx-asr)
+is the recommended engine: it runs ONNX models on CPU, ships a best-model-per-language
+registry covering ~90 languages, and loads a model per request language, so one
+server can serve all of them. Point the plugin at it:
+
+```json
+  "stt": {
+    "module": "ovos-stt-plugin-server",
+    "ovos-stt-plugin-server": {
+      "urls": ["https://your-server.example/stt"]
+    }
+  }
+```
+
 ## Public servers
 
-public server status page can be found at https://github.com/OpenVoiceOS/status
+If you set no `urls`, the plugin falls back to public servers.
 
-the default public servers run [Whisper](https://github.com/OpenVoiceOS/ovos-stt-plugin-fasterwhisper)
+> **These are a community courtesy, not a service.** They exist so you can try
+> OVOS without setting anything up first. They are provided on a best-effort
+> basis with **no guarantees** of uptime, latency, accuracy, privacy, or
+> continued existence, and they can change or disappear without notice. They
+> are meant for demos, evaluation and onboarding — **not for production, and
+> not for anything you would not want a third party to receive**. Audio you
+> send is processed on hardware you do not control.
+>
+> For anything beyond trying it out, [self-host](#self-hosting-recommended).
+
+Status page: https://github.com/TigreGotico/public-servers
 
 While there are associated risks with public servers, we value your trust in our products, learn more in Jarbas blog post [The Trust Factor in Public Servers](https://jarbasal.github.io/blog/2023/10/14/the-trust-factor-in-public-servers.html)
-

--- a/README.md
+++ b/README.md
@@ -78,6 +78,3 @@ If you set no `urls`, the plugin falls back to public servers.
 >
 > For anything beyond trying it out, [self-host](#self-hosting-recommended).
 
-Status page: https://github.com/TigreGotico/public-servers
-
-While there are associated risks with public servers, we value your trust in our products, learn more in Jarbas blog post [The Trust Factor in Public Servers](https://jarbasal.github.io/blog/2023/10/14/the-trust-factor-in-public-servers.html)

--- a/ovos_stt_plugin_server/__init__.py
+++ b/ovos_stt_plugin_server/__init__.py
@@ -95,7 +95,7 @@ class OVOSHTTPServerSTT(STT):
     @property
     def public_servers(self):
         return [
-            "https://whisper.tigregotico.pt/stt",
+            "https://stt.openvoiceos.pt/stt",
             "https://stt.smartgic.io/fasterwhisper/stt",
             # "https://whisper.neonaiservices.com/stt"  # TODO -restore once it moves to whisper-turbo
         ]


### PR DESCRIPTION
The default public STT server (`whisper.tigregotico.pt`) points at a host that no longer serves anything — that domain moved off the proxy, so the fallback silently fails for anyone without `urls` configured. Replaced with `stt.openvoiceos.pt`.

Also reframes the README: self-hosting comes first, with [ovos-stt-plugin-onnx-asr](https://github.com/OpenVoiceOS/ovos-stt-plugin-onnx-asr) as the recommended engine (CPU ONNX, best-model-per-language registry, one server serves ~90 languages). The public-server section now says what these actually are — a community courtesy provided best-effort for demos and easy onboarding, with no guarantees of uptime, latency, accuracy or privacy, and not appropriate for production or sensitive audio.

## Model usage
Authored by Claude (Fable 5); dead endpoint confirmed by request, replacement verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup guidance to recommend self-hosting with `ovos-stt-http-server` and the ONNX speech recognition engine.
  - Added configuration instructions, supported language coverage, and per-language model loading details.
  - Clarified public server fallback behavior and added privacy and best-effort service warnings.
  - Updated the default public speech-to-text server endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->